### PR TITLE
#28 - save session info to file

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,10 +22,10 @@ Imports: DALEX (>= 0.2.2),
     kableExtra (>= 0.9.0),
     psych (>= 1.8.4),
     archivist (>= 2.1.0),
-    svglite (>= 1.2.1)
+    svglite (>= 1.2.1),
+    devtools (>= 2.0.1)
 Suggests: ranger,
-    testthat,
-    devtools
+    testthat
 RoxygenNote: 6.1.1
 URL: https://github.com/MI2DataLab/modelDown
 BugReports: https://github.com/MI2DataLab/modelDown/issues

--- a/R/modelDown.R
+++ b/R/modelDown.R
@@ -80,7 +80,9 @@ modelDown <- function(...,
   }
 
   #save session info
-  writeLines(capture.output(devtools::session_info()), paste0(output_folder,"/session_info/session_info.txt"))
+  session_info <- devtools::session_info()
+  writeLines(capture.output(session_info), paste0(output_folder,"/session_info/session_info.txt"))
+  save(session_info, file = paste0(output_folder,"/session_info/session_info.rda"))
 
   copyAssets(system.file("extdata", "template", package = "modelDown"), output_folder)
 

--- a/R/modelDown.R
+++ b/R/modelDown.R
@@ -78,6 +78,10 @@ modelDown <- function(...,
   for(explainer in explainers){
     saveRDS(explainer, file = paste0(output_folder,"/explainers/", explainer$label, ".rda"))
   }
+
+  #save session info
+  writeLines(capture.output(devtools::session_info()), paste0(output_folder,"/session_info/session_info.txt"))
+
   copyAssets(system.file("extdata", "template", package = "modelDown"), output_folder)
 
   generated_modules <- generateModules(modules, output_folder, explainers, options)
@@ -174,6 +178,9 @@ ensureOutputFolderStructureExist <- function(output_folder) {
 
   img_folder_path <- file.path(output_folder, "img")
   createDirIfNotExists(img_folder_path)
+
+  session_folder_path <- file.path(output_folder, "session_info")
+  createDirIfNotExists(session_folder_path)
 }
 
 renderPage <- function(content, modules, output_path, root_path, extra_css = c()) {

--- a/inst/extdata/template/base_template.html
+++ b/inst/extdata/template/base_template.html
@@ -64,7 +64,7 @@
   <footer>
     <div class="footer">
       <div class="text-center">Site built with <a href="https://github.com/MI2DataLab/modelDown">modelDown</a>.</div>
-      <div class="text-center" style="margin: 0px 0px 5px;">Last updated: {{datetime}} (<a href="session_info/session_info.txt">session_info</a>)</div>
+      <div class="text-center" style="margin: 0px 0px 5px;">Last updated: {{datetime}} (session_info: <a href="session_info/session_info.txt">.txt</a>, <a href="session_info/session_info.rda">.rda</a>)</div>
     </div>
   </footer>
 

--- a/inst/extdata/template/base_template.html
+++ b/inst/extdata/template/base_template.html
@@ -64,7 +64,7 @@
   <footer>
     <div class="footer">
       <div class="text-center">Site built with <a href="https://github.com/MI2DataLab/modelDown">modelDown</a>.</div>
-      <div class="text-center" style="margin: 0px 0px 5px;">Last updated: {{datetime}}</div>
+      <div class="text-center" style="margin: 0px 0px 5px;">Last updated: {{datetime}} (<a href="session_info/session_info.txt">session_info</a>)</div>
     </div>
   </footer>
 


### PR DESCRIPTION
I added link to text file containing output from function `devtools::session_info()`. I placed the link in the footer instead of creating separate module, because it's technical information and doesn't provide information on model itself.